### PR TITLE
Fix missing variable warning

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -2,15 +2,11 @@ defmodule Exreloader.Mixfile do
   use Mix.Project
 
   def project do
-    [ app: :exreloader,
-      version: "0.0.1",
-      deps: deps ]
+    [app: :exreloader, version: "0.0.1", deps: deps()]
   end
 
-  # Configuration for the OTP application
   def application do
-    [applications: [:logger],
-     mod: {ExReloader, []}]
+    [applications: [:logger], mod: {ExReloader, []}]
   end
 
   defp deps do


### PR DESCRIPTION
This fixes the warning message below:

```
warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  mix.exs:7
```